### PR TITLE
Mail stub fix

### DIFF
--- a/mail-stub/defaults/main.yml
+++ b/mail-stub/defaults/main.yml
@@ -6,4 +6,4 @@ mail_db_name: "postfix"
 
 # If you choose to enable tls, this role expects you to have letssencrypt
 # certificates available at /etc/letsencrypt/live/{{ mail_domain }}/
-mail_tls_enable: yes
+mail_enable_tls: yes

--- a/mail-stub/defaults/main.yml
+++ b/mail-stub/defaults/main.yml
@@ -1,2 +1,6 @@
 mail_db_user: "postfix"
 mail_db_name: "postfix"
+
+# Uncomment and fill these variables accordingly
+#mail_db_password: "superSecret"
+#mail_domain: "example.org"

--- a/mail-stub/defaults/main.yml
+++ b/mail-stub/defaults/main.yml
@@ -1,6 +1,9 @@
 mail_db_user: "postfix"
 mail_db_name: "postfix"
-
 # Uncomment and fill these variables accordingly
 #mail_db_password: "superSecret"
 #mail_domain: "example.org"
+
+# If you choose to enable tls, this role expects you to have letssencrypt
+# certificates available at /etc/letsencrypt/live/{{ mail_domain }}/
+mail_tls_enable: yes

--- a/mail-stub/handlers/main.yml
+++ b/mail-stub/handlers/main.yml
@@ -3,3 +3,28 @@
     name=rsyslog
     state=restarted
 
+- name: restart postfix
+  service: 
+    name=postfix
+    state=restarted
+
+- name: restart dovecot
+  service: 
+    name=dovecot
+    state=restarted
+
+- name: restart cron
+  service: 
+    name=cron
+    state=restarted
+
+- name: restart fail2ban
+  service: 
+    name=fail2ban
+    state=restarted
+
+- name: restart postfwd
+  service: 
+    name=postfwd
+    state=restarted
+

--- a/mail-stub/tasks/main.yml
+++ b/mail-stub/tasks/main.yml
@@ -159,7 +159,7 @@
     mode: 640
   notify: restart postfwd
 
-- name: configure postfwd (STARTUP: 1)
+- name: "configure postfwd (STARTUP: 1)"
   lineinfile:
     dest: "/etc/default/postfwd"
     regexp: "^STARTUP=1"

--- a/mail-stub/tasks/main.yml
+++ b/mail-stub/tasks/main.yml
@@ -141,6 +141,22 @@
     mode: 644
   notify: restart dovecot
 
+- name: fix typo in fail2ban jail.conf
+  replace:
+    dest: /etc/fail2ban/jail.conf
+    regexp: '^logpath  = logpath = %\(roundcube_errors_log\)s$'
+    replace: "logpath = %(roundcube_errors_log)s"
+
+- name: create missing roudncube logdir
+  file:
+    path: /var/log/roundcube
+    state: directory
+
+- name: create missing roudncube logfile
+  file:
+    path: /var/log/roundcube/errors
+    state: touch
+
 - name: fail2ban for postfix/dovecot
   copy:
     src: fail2ban-mail.conf

--- a/mail-stub/templates/dovecot_conf.d/10-ssl.conf
+++ b/mail-stub/templates/dovecot_conf.d/10-ssl.conf
@@ -3,14 +3,23 @@
 ##
 
 # SSL/TLS support: yes, no, required. <doc/wiki/SSL.txt>
-#ssl = yes
+{% if mail_enable_tls %}
+ssl = yes
+{% else %}
+ssl = no
+{% endif %}
 
 # PEM encoded X.509 SSL/TLS certificate and private key. They're opened before
 # dropping root privileges, so keep the key file unreadable by anyone but
 # root. Included doc/mkcert.sh can be used to easily generate self-signed
 # certificate, just make sure to update the domains in dovecot-openssl.cnf
+{% if mail_enable_tls %}
 ssl_cert = </etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem
 ssl_key = </etc/letsencrypt/live/{{ mail_domain }}/privkey.pem
+{% else %}
+#ssl_cert = </etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem
+#ssl_key = </etc/letsencrypt/live/{{ mail_domain }}/privkey.pem
+{% endif %}
 
 # If key file is password protected, give the password here. Alternatively
 # give it when starting dovecot with -p parameter. Since this file is often

--- a/mail-stub/templates/main.cf
+++ b/mail-stub/templates/main.cf
@@ -8,6 +8,7 @@ append_dot_mydomain = no
 
 readme_directory = no
 
+{% if mail_enable_tls %}
 smtp_use_tls = yes
 smtp_tls_note_starttls_offer = yes
 smtp_tls_cert_file=/etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem
@@ -22,6 +23,23 @@ smtpd_tls_cert_file=/etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem
 smtpd_tls_key_file=/etc/letsencrypt/live/{{ mail_domain }}/privkey.pem
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtpd_tls_mandatory_protocols = !SSLv2,!SSLv3
+
+{% else %}
+smtp_use_tls = no
+#smtp_tls_note_starttls_offer = yes
+#smtp_tls_cert_file=/etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem
+#smtp_tls_key_file=/etc/letsencrypt/live/{{ mail_domain }}/privkey.pem
+#smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+#smtp_tls_mandatory_protocols = !SSLv2,!SSLv3
+
+smtpd_use_tls = no
+#smtpd_tls_received_header = yes
+#smtpd_tls_auth_only = yes
+#smtpd_tls_cert_file=/etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem
+#smtpd_tls_key_file=/etc/letsencrypt/live/{{ mail_domain }}/privkey.pem
+#smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+#smtpd_tls_mandatory_protocols = !SSLv2,!SSLv3
+{% endif %}
 
 # SASL
 smtpd_sasl_auth_enable = yes


### PR DESCRIPTION
Things fixed/added:

- fixed some typos
- added missing handlers and default variables
- fixed problems that prevented fail2ban from starting
  - typo in fail2ban config ( https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=810287 )
  - missing logfile for roundcube /var/log/roundcube/errors
- added `mail_tls_enable` variable that deploys dovecot/postfix with or without tls config
  - dovecot refused to start if it didn't find letsencrypt certificates for specified domain