### PR TITLE
passwordless sudo -u user

### DIFF
--- a/admins/files/sudoers
+++ b/admins/files/sudoers
@@ -1,2 +1,2 @@
 Defaults env_keep=SSH_AUTH_SOCK
-%sudo ALL=NOPASSWD:ALL
+%sudo ALL=(ALL:ALL) NOPASSWD:ALL


### PR DESCRIPTION
fixes a bug where sudo to root worked, but sudo to other users asked for a password.