### PR TITLE
Slight improvements to Wireguard role

### DIFF
--- a/wireguard/defaults/main.yml
+++ b/wireguard/defaults/main.yml
@@ -15,4 +15,5 @@ wg_peers: {}
 #  allowed_ips: "172.16.0.2/32"
 #  psk: "xxx" (optional)
 #  endpoint: "a.b.c.d:1501" (mandatory for clients)
+#  keepalive: 25 (optional)
 

--- a/wireguard/handlers/main.yml
+++ b/wireguard/handlers/main.yml
@@ -1,4 +1,4 @@
-- name: restart {{ wg_name }} service
+- name: restart wireguard service
   service:
-    name: wg-quick@{{ wg_name }}
+    name: "wg-quick@{{ wg_name }}"
     state: restarted

--- a/wireguard/tasks/main.yml
+++ b/wireguard/tasks/main.yml
@@ -7,6 +7,7 @@
   template:
     src: "wg.conf"
     dest: "/etc/wireguard/{{ wg_name }}.conf"
+    mode: "600"
   notify: restart wireguard service
   tags: configure
 

--- a/wireguard/tasks/main.yml
+++ b/wireguard/tasks/main.yml
@@ -7,10 +7,10 @@
   template:
     src: "wg.conf"
     dest: "/etc/wireguard/{{ wg_name }}.conf"
-  notify: restart {{ wg_name }} service
+  notify: restart wireguard service
   tags: configure
 
-- name: enable {{ wg_name }} service
+- name: enable wireguard service
   systemd:
     name: wg-quick@{{ wg_name }}
     enabled: true


### PR DESCRIPTION
Proposed changes:

- Don't use variables in handler names because they always render name with the default value. E.g. If I set `wg_name` to `my-vpn` in host/group vars the handler will still be named `restart wg0 service` but the task will try to notify `restart my-vpn service` which fails.
- use more strict file permissions for wg config
- mention `keepalive` variable in the defaults since it can be configured for the role