### PR TITLE
harden ssh some more

### DIFF
--- a/harden-ssh/templates/sshd_config
+++ b/harden-ssh/templates/sshd_config
@@ -9,11 +9,19 @@ HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
 
+RekeyLimit {{ sshd_rekey_limit | default('1G') }}
+
+KexAlgorithms {{ sshd_kex_algorithms | default('sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,curve25519-sha256,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512') }}
+Ciphers {{ sshd_ciphers | default('chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr') }}
+MACs {{ sshd_macs | default('umac-128-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com') }}
+
+
 SyslogFacility AUTH
 LogLevel INFO
 
 LoginGraceTime 60
 StrictModes yes
+MaxAuthTries {{ sshd_max_auth_tries | default(5) }}
 
 IgnoreRhosts yes
 HostbasedAuthentication no
@@ -39,7 +47,8 @@ ClientAliveInterval 300
 #MaxStartups 10:30:60
 MaxSessions {{ sshd_max_sessions | default(20) }}
  
-Banner /etc/issue.net
+Banner none
+VersionAddendum none
 
 # Allow client to pass locale environment variables
 AcceptEnv LANG LC_*

--- a/harden-ssh/templates/sshd_config
+++ b/harden-ssh/templates/sshd_config
@@ -8,7 +8,6 @@ HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
-UsePrivilegeSeparation yes
 
 SyslogFacility AUTH
 LogLevel INFO
@@ -34,7 +33,6 @@ X11DisplayOffset 10
 PrintMotd no
 PrintLastLog yes
 TCPKeepAlive yes
-UseLogin no
 UseDNS no
 ClientAliveInterval 300
 


### PR DESCRIPTION
hi,
I added some options you might appreciate to harden SSHd a little more.

some options echoed as deprecated on LTS Ubuntu were removed.

among additions are setting no (or as little of it as possible) banner (some people might rely on the banner for some reason), setting `MaxAuthTries`, rekeying during long-lived sessions after 1G of transferred data, and explicitly setting `KexAlgorithms`, `Ciphers` and `MACs` to modern defaults, with the option to configure this downstream.

it might or might not be too much for what you want to do with it.