### PR TITLE
fix(certbot): make cerbot honor httx_proxy

### DIFF
--- a/letsencrypt/certbot/tasks/main.yml
+++ b/letsencrypt/certbot/tasks/main.yml
@@ -19,6 +19,7 @@
     path: /etc/systemd/system/certbot.service.d
     state: directory
   tags: configure
+  when: proxy_host is not undefined and proxy_port is not undefined
 
 - name: set certbot's proxy values
   community.general.ini_file:
@@ -32,6 +33,7 @@
     option: Environment
     value: "http_proxy=http://{{proxy_host}}:{{proxy_port}} https_proxy=http://{{proxy_host}}:{{proxy_port}}"
   tags: configure
+  when: proxy_host is not undefined and proxy_port is not undefined
 
 - name: make systemd reread configs
   ansible.builtin.systemd_service:

--- a/letsencrypt/certbot/tasks/main.yml
+++ b/letsencrypt/certbot/tasks/main.yml
@@ -11,6 +11,33 @@
     state: present
   tags: install
 
+- name: Create a certbot.service override directory
+  file:
+    owner: root
+    group: root
+    mode: 0755
+    path: /etc/systemd/system/certbot.service.d
+    state: directory
+  tags: configure
+
+- name: set certbot's proxy values
+  community.general.ini_file:
+    dest: /etc/systemd/system/certbot.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0644
+    ignore_spaces: true
+    no_extra_spaces: true
+    section: Service
+    option: Environment
+    value: "http_proxy=http://{{proxy_host}}:{{proxy_port}} https_proxy=http://{{proxy_host}}:{{proxy_port}}"
+  tags: configure
+
+- name: make systemd reread configs
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  tags: configure
+
 - name: configure certbot
   template:
       src: cli.ini

--- a/letsencrypt/certbot/tasks/main.yml
+++ b/letsencrypt/certbot/tasks/main.yml
@@ -19,7 +19,7 @@
     path: /etc/systemd/system/certbot.service.d
     state: directory
   tags: configure
-  when: proxy_host is not undefined and proxy_port is not undefined
+  when: proxy_host is defined and proxy_port is defined
 
 - name: set certbot's proxy values
   community.general.ini_file:
@@ -33,7 +33,7 @@
     option: Environment
     value: "http_proxy=http://{{proxy_host}}:{{proxy_port}} https_proxy=http://{{proxy_host}}:{{proxy_port}}"
   tags: configure
-  when: proxy_host is not undefined and proxy_port is not undefined
+  when: proxy_host is defined and proxy_port is defined
 
 - name: make systemd reread configs
   ansible.builtin.systemd_service:

--- a/letsencrypt/certbot/tasks/main.yml
+++ b/letsencrypt/certbot/tasks/main.yml
@@ -34,11 +34,13 @@
     value: "http_proxy=http://{{proxy_host}}:{{proxy_port}} https_proxy=http://{{proxy_host}}:{{proxy_port}}"
   tags: configure
   when: proxy_host is defined and proxy_port is defined
+  register: certbot_systemd_override
 
 - name: make systemd reread configs
   ansible.builtin.systemd_service:
     daemon_reload: true
   tags: configure
+  when: certbot_systemd_override.changed
 
 - name: configure certbot
   template:


### PR DESCRIPTION
this PR unbreaks `certbot` on proxied systems, where it is not able to talk to LetsEncrypt and fails to renew certs. setting the proxy values in its environment, it can now connect where it needs to.

### TODO
* [x] an additional conditional would be nice, as to whether `http_proxy` is set at all.