### PR TITLE
wazuh: improve port override logic

### DIFF
--- a/wazuh/templates/docker-compose.override.yml
+++ b/wazuh/templates/docker-compose.override.yml
@@ -4,7 +4,12 @@ services:
     container_name: "wazuh.manager"
     volumes:
       - /data/logs:/logs:ro
-{% if wazuh_expose_syslog == False %}
+{% if ( wazuh_custom_ports | type_debug == 'list' ) and (wazuh_custom_ports | length > 0) %}
+    ports: !override {{ wazuh_custom_ports }}
+{% else %}
+    # overriding the defaults still, because there usually is syslog-ng
+    # listening on 514, which means it would collide with the upstream defaults
+    # of also listening on 514.
     ports: !override
       - "1514:1514"
       - "1515:1515"


### PR DESCRIPTION
wherever wazuh is deployed, there is already probably `syslog-ng` running, and it is listening on 514.
meaning the port override should be a default in our case (it effectively was with the previous variable defaulting to false), but this change gives it a clearer name and an option to completely override ports.

the previous logic would try to listen on 514, which would already be taken and result in the compose failing to start (or syslog-ng on next system start).

this new logic allows overriding the ports array entirely, and thus also specifying custom ports for syslog that are not taken on the host (e.g. 5144).