### PR TITLE
harden-ssh some more

### DIFF
--- a/harden-ssh/templates/sshd_config
+++ b/harden-ssh/templates/sshd_config
@@ -4,7 +4,6 @@ ListenAddress 0.0.0.0
 Port 22
 Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 


### PR DESCRIPTION
this change disables DSA hostkeys, which e.g. on Ubuntu 22.04 Server edition is not generated by default.